### PR TITLE
Small changes to prepare_data

### DIFF
--- a/doc/prepare_data.md
+++ b/doc/prepare_data.md
@@ -13,7 +13,7 @@ The script returns the geology.nc file as necessary for run
 IGM for a forward glacier evolution run, and optionaly 
 observation.nc that permit to do a first step of data assimilation & inversion. 
 Data are currently based on COPERNIUS DEM 90 
-the RGI, and the ice thckness and velocity from (MIllan, 2022) 
+the RGI, and the ice thckness and velocity from (Millan, 2022) 
 For the ice thickness in geology.nc, the use can choose 
 between consensus_ice_thickness (farinotti2019) or
 millan_ice_thickness (millan2022) dataset 
@@ -22,7 +22,29 @@ downloaded from the GlaThiDa depo (https://gitlab.com/wgms/glathida)
 and are rasterized on working grids 
 Script written by G. Jouvet & F. Maussion & E. Welty
 
-The module takes all input variable fields neede to run IGM inverse and/or forward
+The module takes all input variable fields needed to run IGM inverse and/or forward
+
+# Installing OGGM for IGM
+
+OGGM is used to fetch pre-processed data from the OGGM servers. For this 
+functionality, the following minimal conda/mamba environment should be enough:
+
+```
+name: oggm_igm_minimal
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  - geopandas
+  - salem
+  - matplotlib
+  - configobj
+  - netcdf4
+  - xarray
+  - oggm
+```
+
+You'll need to add the packages required by IGM of course.
  
 # Parameters: 
 

--- a/igm/modules/preproc/prepare_data.py
+++ b/igm/modules/preproc/prepare_data.py
@@ -206,13 +206,25 @@ def _oggm_util(RGIs, params):
     import oggm.cfg as cfg
     from oggm import utils, workflow, tasks, graphics
 
-    # Initialize OGGM and set up the default run parameters
-    cfg.initialize()
-
-    cfg.PARAMS["continue_on_error"] = False
-    cfg.PARAMS["use_multiprocessing"] = False
-
     if params.preprocess:
+        # This uses OGGM preprocessed directories
+        # I think that a minimal environment should be enough for this to run
+        # Required packages:
+        #   - numpy
+        #   - geopandas
+        #   - salem
+        #   - matplotlib
+        #   - configobj
+        #   - netcdf4
+        #   - xarray
+        #   - oggm
+
+        # Initialize OGGM and set up the default run parameters
+        cfg.initialize_minimal()
+
+        cfg.PARAMS["continue_on_error"] = False
+        cfg.PARAMS["use_multiprocessing"] = False
+
         WD = "OGGM-prepro"
 
         # Where to store the data for the run - should be somewhere you have access to
@@ -222,14 +234,25 @@ def _oggm_util(RGIs, params):
         rgi_ids = utils.get_rgi_glacier_entities(RGIs)
 
         base_url = (
-            "https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/exps/igm_v1"
+            "https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/exps/igm_v2"
         )
         gdirs = workflow.init_glacier_directories(
-            rgi_ids, prepro_border=30, from_prepro_level=2, prepro_base_url=base_url
+            # Start from level 3 if you want some climate data in them
+            rgi_ids, prepro_border=40, from_prepro_level=2, prepro_base_url=base_url
         )
 
     else:
+        # Note: if you start from here you'll need most of the packages
+        # needed by OGGM, since you start "from scratch" entirely
+        # In my view this code should almost never be needed
+
         WD = "OGGM-dir"
+
+        # Initialize OGGM and set up the default run parameters
+        cfg.initialize()
+
+        cfg.PARAMS["continue_on_error"] = False
+        cfg.PARAMS["use_multiprocessing"] = False
 
         # Map resolution parameters
         cfg.PARAMS["grid_dx_method"] = "fixed"


### PR DESCRIPTION
As discussed, I tested the smallest environment necessary to run OGGM with your use case, and I managed to get it to work with a quite small environment:

```
name: oggm_igm_minimal
channels:
  - conda-forge
dependencies:
  - numpy
  - geopandas
  - salem
  - matplotlib
  - configobj
  - netcdf4
  - xarray
  - oggm
```

This should be enough to download the data you need (I hope). IGM dependencies not included yet.

I also updated the URL to use the version 2 of the data I generated for IGM (no big changes expected, but it uses a slightly bigger map (border 40 instead of 30), and users have the option to go to level 3 of preprocessing if they want to use climate data and more. 

You should test this before merging maybe.
