### PR TITLE
small bug fix which occurs if you customize the params function

### DIFF
--- a/igm/modules/postproc/print_info.py
+++ b/igm/modules/postproc/print_info.py
@@ -9,7 +9,7 @@ import datetime
 import matplotlib.pyplot as plt
 
 
-def params_print_info(state):
+def params_print_info(parser):
     pass
 
 

--- a/igm/modules/process/thk.py
+++ b/igm/modules/process/thk.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 from igm.modules.utils import compute_divflux
 
 
-def params_thk(state):
+def params_thk(parser):
     pass
 
 def initialize_thk(params, state):


### PR DESCRIPTION
Hey Guillaume, I realized some modules still have an outdated argument in the params_[module_name] function. This leads to an error as soon as you want to add parameters in this functions.