### PR TITLE
Progress with gFlex module

### DIFF
--- a/igm/modules/process/gflex.py
+++ b/igm/modules/process/gflex.py
@@ -139,11 +139,15 @@ def update_gflex(params, state):
                         
             state.flex.w = griddata(points, values, (target_X, target_Y), method='linear')
         else:
-            pad_arrays(params,state)
+            p = pad_arrays(params,state)
             state.flex.initialize()
             state.flex.run()
             state.flex.finalize()
+            
+            # remove the padded cols and rows
+            state.flex.w = state.flex.w[p:-p,p:-p]
         
+        # add the deflection to the topography 
         state.topg = state.topg0 + state.flex.w
         state.usurf = state.topg + state.thk
         # state.flex.plotChoice='both'

--- a/igm/modules/process/gflex.py
+++ b/igm/modules/process/gflex.py
@@ -99,13 +99,14 @@ def update_gflex(params, state):
         state.flex.Te = state.flex.Te.numpy()        
         state.flex.qs = state.thk.numpy() * 917 * 9.81  # Populating this template
         
-        if state.dx < 1000:
-            state.flex.Te, target_points,points, x, y = downsample_array_to_resolution(state.flex.Te, state.flex.dx, 1000)
-            state.flex.qs, target_points,points, x, y = downsample_array_to_resolution(state.flex.qs, state.flex.dx, 1000)
+        if state.dx < 2000:
+            state.flex.Te, target_points,points, x, y = downsample_array_to_resolution(state.flex.Te, state.flex.dx, 2000)
+            state.flex.qs, target_points,points, x, y = downsample_array_to_resolution(state.flex.qs, state.flex.dx, 2000)
             state.flex.initialize()
             state.flex.run()
             state.flex.finalize()
             state.flex.w = upsample_result_to_original_resolution(state.flex.w, target_points, points, x, y, state.flex.dx)
+            state.flex.w = np.float32(state.flex.w)
         else:
             state.flex.initialize()
             state.flex.run()


### PR DESCRIPTION
When the load extents close to the grid margins some unwanted boundary effects could occur. For example, when fixing the elastic plate at the margins (0Displacement0Slope) it cannot freely deflect close to the boundaries. Therefore we can extent the grids (Te & load) beyond their original dimensions by using numpy.pad. The number of padded cells thereby represents one flexural wavelength, which depends on Te, E and nu. After the deflection grid has been computed, the padded cells are being removed again and the deflection is applied to the initial topography. At the moment this works for constant Te only.