### PR TITLE
allow RGI 7 "C" or "G" IDs in oggm_shop

### DIFF
--- a/igm/modules/preproc/oggm_shop/oggm_shop.py
+++ b/igm/modules/preproc/oggm_shop/oggm_shop.py
@@ -310,7 +310,7 @@ def _oggm_util(RGIs, params):
                 rgi_ids,
                 prepro_border=40,
                 from_prepro_level=3,
-                prepro_rgi_version='70C',
+                prepro_rgi_version='70' + params.oggm_RGI_ID[13], # "C" for glacier complexes, "G" for individual glaciers
                 prepro_base_url=base_url,
             )
 


### PR DESCRIPTION
This line had `prepro_rgi_version='70C'` hardcoded so that only data from the RGI 7 "C" product (glacier complexes) could be downloaded from the OGGM shop. This change allows for downloading data for either "C" glaciers or "G" (individual) glaciers. `params.oggm_RGI_ID[13]` is simply the character `'C'` or `'G'` in the RGI ID.