### PR TITLE
Fixed oggm_shop bug where thkinit was hardcoded as Millan

### DIFF
--- a/igm/modules/preproc/oggm_shop/oggm_shop.py
+++ b/igm/modules/preproc/oggm_shop/oggm_shop.py
@@ -208,9 +208,9 @@ def initialize(params, state):
     uvelsurfobs = scipy.signal.medfilt2d(uvelsurfobs, kernel_size=3) # remove outliers
     vvelsurfobs = scipy.signal.medfilt2d(vvelsurfobs, kernel_size=3) # remove outliers
 
-    if "millan_ice_thickness" in nc.variables:
+    if params.oggm_thk_source in nc.variables: # either "millan_ice_thickness" or "consensus_ice_thickness"
         thkinit = np.flipud(
-            np.squeeze(nc.variables["millan_ice_thickness"]).astype("float32")
+            np.squeeze(nc.variables[params.oggm_thk_source]).astype("float32")
         )
         thkinit = np.where(np.isnan(thkinit), 0, thkinit)
         thkinit = np.where(icemaskobs, thkinit, 0)


### PR DESCRIPTION
Fixed oggm_shop bug where the variable `"thkinit"` was hardcoded as Millan. Now when running optimize module, users have the option to initialize thickness field as either consensus (default) or Millan.

Note that if re-using any params.json files where `"oggm_thk_source"` was not specified, this patch will change the initial thickness field - previously it would have been `"millan_ice_thickness"` as that was hardcoded, now it will be `"consensus_ice_thickness"` as that is the default value for `"oggm_thk_source"`.