### PR TITLE
update avalanche.py, add consistent param names, code annotations and new exit strategy

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
         python -m build
         twine check --strict dist/*
     - name: Create artifact for release job
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist_folder
         path: dist
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dist_folder
         path: dist

--- a/igm/modules/process/avalanche/avalanche.md
+++ b/igm/modules/process/avalanche/avalanche.md
@@ -8,3 +8,6 @@ at angle of repose. This function was adapted from
 [Mark Kessler's GC2D](https://github.com/csdms-contrib/gc2d)
 program and implemented in IGM by Jürgen Mey with support from Guillaume Jouvet.
  
+Modified exit strategy, annotated and documented by Andreas Henz
+
+The redistribution of snow is done in each specific time step `aval_update_freq` and based on a maximum slope angle `aval_angleOfRepose`. Basically, the ice is redistributed downwards in an iterative process to achieve a maximum surface slope (in the code a maximum height difference between neighboring grid cells). This iterative process is stopped when the average distributed ice is less than a certain thickness `aval_stop_redistribution_thk`. This initial value (recommended between 1-5 cm) was determined by looking at the amount of ice distributed at each time step. If very little ice is distributed, we stop the loop and save computation time.

--- a/igm/modules/process/avalanche/avalanche.py
+++ b/igm/modules/process/avalanche/avalanche.py
@@ -37,7 +37,7 @@ def initialize(params, state):
 
 
 def update(params, state):
-    if (state.t - state.tlast_avalanche) >= params.avalanche_update_freq:
+    if (state.t - state.tlast_avalanche) >= params.aval_update_freq:
         if hasattr(state, "logger"):
             state.logger.info("Update AVALANCHE at time : " + str(state.t.numpy()))
 
@@ -49,7 +49,7 @@ def update(params, state):
         
         # the elevation difference of the cells that is considered to be stable
         dHRepose = state.dx * tf.math.tan(
-            params.avalanche_angleOfRepose * np.pi / 180.0
+            params.aval_angleOfRepose * np.pi / 180.0
         )
         Ho = tf.maximum(H, 0)
 

--- a/igm/modules/process/avalanche/avalanche.py
+++ b/igm/modules/process/avalanche/avalanche.py
@@ -10,17 +10,24 @@ import time
 
 def params(parser):
     parser.add_argument(
-        "--avalanche_update_freq",
+        "--aval_update_freq",
         type=float,
         default=1,
         help="Update avalanche each X years (1)",
     )
 
     parser.add_argument(
-        "--avalanche_angleOfRepose",
+        "--aval_angleOfRepose",
         type=float,
         default=30,
         help="Angle of repose (30°)",
+    )
+    
+    parser.add_argument(
+        "--aval_stop_redistribution_thk",
+        type=float,
+        default=0.02,
+        help="Stop redistribution if the mean thickness is below this value (m) over the whole grid",
     )
 
 
@@ -39,15 +46,22 @@ def update(params, state):
         H = state.thk
         Zb = state.topg
         Zi = Zb + H
+        
+        # the elevation difference of the cells that is considered to be stable
         dHRepose = state.dx * tf.math.tan(
             params.avalanche_angleOfRepose * np.pi / 180.0
         )
         Ho = tf.maximum(H, 0)
 
         count = 0
+        # volume redistributed # for documentation if needed
+        # volumes = []
+        
 
-        while True:
+        while count <=300:
             count += 1
+            
+            # find out, in which direction is down (instead of doing normal gradients, we do the max of the two directions)
 
             dZidx_down = tf.pad(
                 tf.maximum(Zi[:, 1:] - Zi[:, :-1], 0), [[0, 0], [1, 0]], "CONSTANT"
@@ -67,19 +81,29 @@ def update(params, state):
 
             grad = tf.math.sqrt(dZidx**2 + dZidy**2)
             gradT = dZidy_left + dZidy_right + dZidx_down + dZidx_up
-            gradT = tf.where(gradT == 0, 1, gradT)
+            gradT = tf.where(gradT == 0, 1, gradT) # avoid devide by zero error. However, could influence the results (not checked) 
             grad = tf.where(Ho < 0.1, 0, grad)
 
-            mxGrad = tf.reduce_max(grad)
-            if mxGrad <= 1.1 * dHRepose:
-                break
-
             delH = tf.maximum(0, (grad - dHRepose) / 3.0)
+
+            # ============ ANDREAS ADDED ===========
+            # if there is less than a certain thickness to redesitribute, just redistribute the remaining thickness and stop afterwards
+            # print(count, np.max(delH), np.sum(delH) / (np.shape(H)[0]*np.shape(H)[1]))
+            mean_thickness = np.sum(delH) / (np.shape(H)[0]*np.shape(H)[1])
+            
+            if mean_thickness < params.aval_stop_redistribution_thk:
+                # for a last time, use all the thickness to redistribute and then stop
+                delH = tf.maximum(0, grad - dHRepose)
+                count = 2000 # set to random high number to exit the loop
+                
+            # volumes.append(np.sum(delH) / (np.shape(H)[0]*np.shape(H)[1]))                
+            # ================================
 
             Htmp = Ho
             Ho = tf.maximum(0, Htmp - delH)
             delH = Htmp - Ho
 
+            # The thickness that is redistributed to the neighboring cells based on the fraction of if it should be up, down, left or right (dZidx_**/gradT)
             delHup = tf.pad(
                 delH[:, :-1] * dZidx_up[:, :-1] / gradT[:, :-1],
                 [[0, 0], [1, 0]],
@@ -100,15 +124,12 @@ def update(params, state):
                 [[0, 1], [0, 0]],
                 "CONSTANT",
             )
-
+            
+            # calculate new thickness after distribution ensuring that the thickness is always positive
             Ho = tf.maximum(0, Ho + delHdn + delHup + delHlt + delHrt)
 
             Zi = Zb + Ho
 
-        # print(count)
-
-        # fig = plt.figure(figsize=(10, 10))
-        # plt.imshow( Ho + tf.where(H<0,H,0) - state.thk ,origin='lower'); plt.colorbar()
 
         state.thk = Ho + tf.where(H < 0, H, 0)
 


### PR DESCRIPTION
New parameter aval_stop_redistribution_thk sets the averaged thickness where redistribution loop is exited.