### PR TITLE
Updated Dockerfile to TensorFlow 2.15.1 and specified user and group ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # docker build --no-cache -t igm --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .
 #
-FROM tensorflow/tensorflow:2.14.0.post1-gpu
+FROM tensorflow/tensorflow:2.15.0.post1-gpu
 
 RUN apt-get update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # docker build --no-cache -t igm --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) .
 #
-FROM tensorflow/tensorflow:2.12.0-gpu
+FROM tensorflow/tensorflow:2.14.0.post1-gpu
 
 RUN apt-get update
 
 # Add user
-ARG USER_ID
-ARG GROUP_ID
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
 RUN addgroup --gid $GROUP_ID igmuser
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID igmuser


### PR DESCRIPTION
Updated TensorFlow to version 2.15.0.post1-gpu. Updated user permission handling by specifying USER_ID/GROUP_ID to the default value of 1000. 