### PR TITLE
Preserve oggm_shop dataset attributes like projection. 

### DIFF
--- a/igm/igm_run.py
+++ b/igm/igm_run.py
@@ -53,8 +53,9 @@ def main(cfg: DictConfig) -> None:
     for gpu_instance in gpus:
         tf.config.experimental.set_memory_growth(gpu_instance, True)
     
-    print([gpus[i] for i in cfg.core.hardware.visible_gpus])
     if gpus:
+        print([gpus[i] for i in cfg.core.hardware.visible_gpus])
+
         try:
             selected_visible_gpus = [gpus[i] for i in cfg.core.hardware.visible_gpus]
             tf.config.set_visible_devices(selected_visible_gpus, "GPU")

--- a/igm/inputs/oggm_shop/open_gridded_data.py
+++ b/igm/inputs/oggm_shop/open_gridded_data.py
@@ -19,10 +19,10 @@ def open_gridded_data(cfg, path_RGI, state, flip_y=True):
         return
 
     ds = xr.open_dataset(ncpath)
-
+    attr = ds.attrs
     # Convert all data to float32
     ds = ds.map(lambda x: x.astype("float32") if hasattr(x, 'dtype') and np.issubdtype(x.dtype, np.floating) else x)
-
+    ds.attrs = attr
     # Ensure coordinates are set
     ds = ds.assign_coords({
         "x": ds["x"].squeeze().astype("float32"),


### PR DESCRIPTION
I tried to fix two bugs:

IGM did not run on CPU because of a print of available GPUs. I moved this inside the if gpu: block.

Information about the projections was omitted during the oggm_shop procedure. I safe the attributes and attached them to the new dataset. 