### PR TITLE
Adapt instructed oggm to v3

### DIFF
--- a/igm/common/__init__.py
+++ b/igm/common/__init__.py
@@ -6,6 +6,8 @@ from .runner import (
     finalize_modules,
     setup_igm_modules,
     check_incompatilities_in_parameters_file,
+    load_yaml_as_cfg,
+    EmptyClass
 )
 
 from .utilities import (

--- a/igm/common/runner/__init__.py
+++ b/igm/common/runner/__init__.py
@@ -1,4 +1,4 @@
-from .configuration import check_incompatilities_in_parameters_file
+from .configuration import check_incompatilities_in_parameters_file, EmptyClass, load_yaml_as_cfg
 
 from .modules import (
     initialize_modules,

--- a/igm/common/runner/configuration/__init__.py
+++ b/igm/common/runner/configuration/__init__.py
@@ -1,1 +1,2 @@
-from .utils import check_incompatilities_in_parameters_file
+from .utils import check_incompatilities_in_parameters_file, EmptyClass
+from .loader import load_yaml_as_cfg

--- a/igm/instructed_oggm.py
+++ b/igm/instructed_oggm.py
@@ -15,6 +15,7 @@ from oggm import cfg, utils
 from oggm.cfg import G, SEC_IN_YEAR, SEC_IN_DAY
 
 import igm
+from igm.common import State, EmptyClass, load_yaml_as_cfg
 from oggm.core.sia2d import Model2D
 
 class IGM_Model2D(Model2D):
@@ -75,10 +76,10 @@ class IGM_Model2D(Model2D):
         
         """
 
-        self.state = igm.State() 
+        self.state = State()
 
-        self.cfg = igm.EmptyClass()  
-        self.cfg.processes = igm.load_yaml_as_cfg(os.path.join("conf","processes","iceflow.yaml"))
+        self.cfg = EmptyClass()
+        self.cfg.processes = load_yaml_as_cfg(os.path.join("..", "..", "..", "conf","processes","iceflow.yaml"))
 
         # Parameter
         self.cfl = 0.25
@@ -122,7 +123,7 @@ class IGM_Model2D(Model2D):
 
         # retrurn the divergence of the flux using upwind fluxes
         divflux = (
-            igm.processes.utils.compute_divflux(
+            igm.utils.gradient.compute_divflux.compute_divflux(
                 self.state.ubar,
                 self.state.vbar,
                 self.state.thk,


### PR DESCRIPTION
These changes let me use instructed_oggm with IGM v3. 

Feel free to adapt these changes to fit the rest of the coding style of your repository.