### PR TITLE
Minor changes to `smb_simple`

### DIFF
--- a/igm/processes/smb_simple/smb_simple.py
+++ b/igm/processes/smb_simple/smb_simple.py
@@ -18,6 +18,9 @@ def initialize(cfg, state):
     else:
         state.smbpar = np.array(cfg.processes.smb_simple.array[1:]).astype(np.float32)
 
+    if len(state.smbpar.shape)==1:  # update() expects 2D array even if state.smbpar has only one row
+        state.smbpar = np.expand_dims(state.smbpar, axis=0)
+
     state.tlast_mb = tf.Variable(-1.0e5000)
 
 

--- a/igm/processes/smb_simple/smb_simple.py
+++ b/igm/processes/smb_simple/smb_simple.py
@@ -11,7 +11,7 @@ def initialize(cfg, state):
 
     if cfg.processes.smb_simple.array == []:
         state.smbpar = np.loadtxt(
-            cfg.processes.smb_simple.file,
+            state.original_cwd.joinpath("experiment", cfg.processes.smb_simple.file),
             skiprows=1,
             dtype=np.float32,
         )


### PR DESCRIPTION
Fix a couple of issues with `smb_simple` that arise when using `processes.smb_simple.file` rather than `array`.

- Assume the file containing the SMB parameters is in the `experiment` directory. Before this change, the file cannot be found unless specifying the filepath as e.g. `file: ../../../experiment/smb_params.txt` in `params.yaml`. After this change, we can keep the file in `experiment` (which seems like a sensible place for it) and just have `file: smb_params.txt` which is cleaner.
- If the file only has one row (which might be the case if your SMB function is constant in time) then `np.loadtxt()` will load it as a 1D array, which then causes an `IndexError` during `update()`. This change just checks for a 1D array and expands dims if that is the case.